### PR TITLE
Add modular presence sensors for white-light control

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 # - Scheduled OTA updates (daily at configured HH:MM) — updates can add new effects
 # - Wi‑Fi + SNTP time sync; NVS persistence for OTA schedule
 # - Clean module separation: ws2812, effects, mqtt, ota, time_sync
+# - Optional PIR and HC-SR04 sensors drive white-light brightness for presence-aware lighting
 #
 # Build
 # idf.py set-target esp32c3

--- a/components/presence/CMakeLists.txt
+++ b/components/presence/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "presence.c" INCLUDE_DIRS ".")

--- a/components/presence/presence.c
+++ b/components/presence/presence.c
@@ -1,0 +1,96 @@
+#include "presence.h"
+#include "sdkconfig.h"
+#include "driver/gpio.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "esp_rom_sys.h"
+
+static const char *TAG = "presence";
+
+static presence_cb_t s_cb;
+static presence_state_t s_state = PRESENCE_NONE;
+
+#if CONFIG_APP_ENABLE_PIR
+static const gpio_num_t PIR_GPIO = CONFIG_APP_PIR_GPIO;
+#endif
+
+#if CONFIG_APP_ENABLE_ULTRASONIC
+static const gpio_num_t TRIG_GPIO = CONFIG_APP_ULTRASONIC_TRIG_GPIO;
+static const gpio_num_t ECHO_GPIO = CONFIG_APP_ULTRASONIC_ECHO_GPIO;
+static const int NEAR_CM = CONFIG_APP_ULTRASONIC_NEAR_CM;
+#endif
+
+static void presence_task(void *arg) {
+    (void)arg;
+    while (1) {
+        presence_state_t new_state = PRESENCE_NONE;
+#if CONFIG_APP_ENABLE_ULTRASONIC
+        gpio_set_level(TRIG_GPIO, 0);
+        ets_delay_us(2);
+        gpio_set_level(TRIG_GPIO, 1);
+        ets_delay_us(10);
+        gpio_set_level(TRIG_GPIO, 0);
+        int64_t t0 = esp_timer_get_time();
+        int64_t timeout = t0 + 40000; // 40ms timeout
+        while (gpio_get_level(ECHO_GPIO) == 0 && esp_timer_get_time() < timeout) {}
+        t0 = esp_timer_get_time();
+        while (gpio_get_level(ECHO_GPIO) == 1 && esp_timer_get_time() < timeout) {}
+        int64_t t1 = esp_timer_get_time();
+        float dist = (t1 - t0) / 58.0f;
+        if (dist > 0 && dist <= NEAR_CM) {
+            new_state = PRESENCE_NEAR;
+        }
+#endif
+#if CONFIG_APP_ENABLE_PIR
+        if (new_state != PRESENCE_NEAR && gpio_get_level(PIR_GPIO)) {
+            new_state = PRESENCE_PRESENT;
+        }
+#endif
+        if (new_state != s_state) {
+            s_state = new_state;
+            if (s_cb) s_cb(s_state);
+            ESP_LOGI(TAG, "state %d", s_state);
+        }
+        vTaskDelay(pdMS_TO_TICKS(500));
+    }
+}
+
+esp_err_t presence_init(presence_cb_t cb) {
+    s_cb = cb;
+#if CONFIG_APP_ENABLE_PIR
+    gpio_config_t pir_conf = {
+        .pin_bit_mask = 1ULL<<PIR_GPIO,
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&pir_conf);
+#endif
+#if CONFIG_APP_ENABLE_ULTRASONIC
+    gpio_config_t trig_conf = {
+        .pin_bit_mask = 1ULL<<TRIG_GPIO,
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&trig_conf);
+    gpio_set_level(TRIG_GPIO, 0);
+
+    gpio_config_t echo_conf = {
+        .pin_bit_mask = 1ULL<<ECHO_GPIO,
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&echo_conf);
+#endif
+#if CONFIG_APP_ENABLE_PIR || CONFIG_APP_ENABLE_ULTRASONIC
+    xTaskCreate(presence_task, "presence", 4096, NULL, 5, NULL);
+#endif
+    return ESP_OK;
+}

--- a/components/presence/presence.h
+++ b/components/presence/presence.h
@@ -1,0 +1,16 @@
+#ifndef PRESENCE_H
+#define PRESENCE_H
+
+#include "esp_err.h"
+
+typedef enum {
+    PRESENCE_NONE = 0,
+    PRESENCE_PRESENT,
+    PRESENCE_NEAR,
+} presence_state_t;
+
+typedef void (*presence_cb_t)(presence_state_t state);
+
+esp_err_t presence_init(presence_cb_t cb);
+
+#endif // PRESENCE_H

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -39,6 +39,62 @@ config APP_OTA_SKIP_CERT_VALIDATION
     bool "Skip TLS certificate validation (development only)"
     default n
 
+menu "Presence Sensors"
+
+config APP_ENABLE_PIR
+    bool "Enable PIR motion sensor"
+    default n
+
+config APP_PIR_GPIO
+    int "PIR sensor GPIO"
+    depends on APP_ENABLE_PIR
+    range 0 40
+    default 33
+
+config APP_ENABLE_ULTRASONIC
+    bool "Enable HC-SR04 ultrasonic sensor"
+    default n
+
+config APP_ULTRASONIC_TRIG_GPIO
+    int "Ultrasonic trigger GPIO"
+    depends on APP_ENABLE_ULTRASONIC
+    range 0 40
+    default 26
+
+config APP_ULTRASONIC_ECHO_GPIO
+    int "Ultrasonic echo GPIO"
+    depends on APP_ENABLE_ULTRASONIC
+    range 0 40
+    default 27
+
+config APP_ULTRASONIC_NEAR_CM
+    int "Distance (cm) considered 'near'"
+    depends on APP_ENABLE_ULTRASONIC
+    range 1 500
+    default 50
+
+config APP_PRESENCE_LOW_BRIGHTNESS_PCT
+    int "Brightness when presence detected (%)"
+    range 0 100
+    default 20
+
+config APP_PRESENCE_NEAR_BRIGHTNESS_PCT
+    int "Brightness when near (%)"
+    range 0 100
+    default 100
+
+config APP_NEAR_LIGHT1_GPIO
+    int "GPIO for extra light 1 (-1 to disable)"
+    range -1 40
+    default -1
+
+config APP_NEAR_LIGHT2_GPIO
+    int "GPIO for extra light 2 (-1 to disable)"
+    range -1 40
+    default -1
+
+endmenu
+
 endmenu
 
 menu "UltraLights OTA"

--- a/main/main.c
+++ b/main/main.c
@@ -13,6 +13,8 @@
 #include "time_sync.h"
 #include "effects.h"
 #include "ws2812.h"
+#include "presence.h"
+#include "driver/gpio.h"
 
 static const char *TAG = "APP";
 
@@ -64,6 +66,47 @@ static void mqtt_ota_schedule(int hour, int minute, const char* url) {
     ota_schedule_set(hour, minute, url);
 }
 
+#if CONFIG_APP_ENABLE_PIR || CONFIG_APP_ENABLE_ULTRASONIC
+static uint8_t pct_to_rgb(int pct) {
+    if (pct < 0) pct = 0; if (pct > 100) pct = 100;
+    return (uint8_t)((pct * 255) / 100);
+}
+
+static void presence_cb(presence_state_t st) {
+    uint8_t low = pct_to_rgb(CONFIG_APP_PRESENCE_LOW_BRIGHTNESS_PCT);
+    uint8_t high = pct_to_rgb(CONFIG_APP_PRESENCE_NEAR_BRIGHTNESS_PCT);
+    switch (st) {
+    case PRESENCE_NEAR:
+        effects_set_static((rgb_t){high, high, high});
+#if CONFIG_APP_NEAR_LIGHT1_GPIO >= 0
+        gpio_set_level(CONFIG_APP_NEAR_LIGHT1_GPIO, 1);
+#endif
+#if CONFIG_APP_NEAR_LIGHT2_GPIO >= 0
+        gpio_set_level(CONFIG_APP_NEAR_LIGHT2_GPIO, 1);
+#endif
+        break;
+    case PRESENCE_PRESENT:
+        effects_set_static((rgb_t){low, low, low});
+#if CONFIG_APP_NEAR_LIGHT1_GPIO >= 0
+        gpio_set_level(CONFIG_APP_NEAR_LIGHT1_GPIO, 0);
+#endif
+#if CONFIG_APP_NEAR_LIGHT2_GPIO >= 0
+        gpio_set_level(CONFIG_APP_NEAR_LIGHT2_GPIO, 0);
+#endif
+        break;
+    default:
+        effects_set_static((rgb_t){0,0,0});
+#if CONFIG_APP_NEAR_LIGHT1_GPIO >= 0
+        gpio_set_level(CONFIG_APP_NEAR_LIGHT1_GPIO, 0);
+#endif
+#if CONFIG_APP_NEAR_LIGHT2_GPIO >= 0
+        gpio_set_level(CONFIG_APP_NEAR_LIGHT2_GPIO, 0);
+#endif
+        break;
+    }
+}
+#endif
+
 void app_main(void) {
     nvs_init_robust();
 
@@ -76,6 +119,17 @@ void app_main(void) {
     ws2812_init(led_count, led_gpio);
     effects_init(led_count, led_gpio);
 
+#if CONFIG_APP_NEAR_LIGHT1_GPIO >= 0
+    gpio_reset_pin(CONFIG_APP_NEAR_LIGHT1_GPIO);
+    gpio_set_direction(CONFIG_APP_NEAR_LIGHT1_GPIO, GPIO_MODE_OUTPUT);
+    gpio_set_level(CONFIG_APP_NEAR_LIGHT1_GPIO, 0);
+#endif
+#if CONFIG_APP_NEAR_LIGHT2_GPIO >= 0
+    gpio_reset_pin(CONFIG_APP_NEAR_LIGHT2_GPIO);
+    gpio_set_direction(CONFIG_APP_NEAR_LIGHT2_GPIO, GPIO_MODE_OUTPUT);
+    gpio_set_level(CONFIG_APP_NEAR_LIGHT2_GPIO, 0);
+#endif
+
     effect_t eff; rgb_t col;
     if (state_load(&eff, &col)) {
         effects_set_static_color(col);
@@ -87,6 +141,10 @@ void app_main(void) {
     }
 
     xTaskCreate(effect_task, "effect", 4096, NULL, 5, NULL);
+
+#if CONFIG_APP_ENABLE_PIR || CONFIG_APP_ENABLE_ULTRASONIC
+    presence_init(presence_cb);
+#endif
 
     mqtt_callbacks_t cbs = {
         .on_ota_now = mqtt_ota_now,


### PR DESCRIPTION
## Summary
- add menuconfig options to enable PIR or HC-SR04 sensors
- implement presence component to detect motion and distance
- drive white-light brightness and optional extra lights based on presence state

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68ad64168cd483268cb22f8641a1c3a8