### PR TITLE
Add modular PIR and ultrasonic presence sensors

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -6,6 +6,7 @@ idf_component_register(
         "mqtt_ctrl.c"
         "ota_update.c"
         "time_sync.c"
+        "presence.c"
     INCLUDE_DIRS
         "."
     REQUIRES
@@ -21,4 +22,5 @@ idf_component_register(
         app_update
         effects
         ws2812
+        driver
 )

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -64,3 +64,52 @@ config APP_MANIFEST_HMAC_HEX
     default ""  # put 64 hex chars (32 bytes) when you enable signed manifests
 
 endmenu
+
+menu "Presence Sensors"
+
+config APP_ENABLE_PIR
+    bool "Enable PIR motion sensor"
+    default n
+
+config APP_PIR_GPIO
+    int "PIR sensor GPIO"
+    depends on APP_ENABLE_PIR
+    range 0 39
+    default 26
+
+config APP_ENABLE_ULTRASONIC
+    bool "Enable HC-SR04 ultrasonic sensor"
+    default n
+
+config APP_US_TRIG_GPIO
+    int "Ultrasonic trigger GPIO"
+    depends on APP_ENABLE_ULTRASONIC
+    range 0 39
+    default 27
+
+config APP_US_ECHO_GPIO
+    int "Ultrasonic echo GPIO"
+    depends on APP_ENABLE_ULTRASONIC
+    range 0 39
+    default 14
+
+config APP_US_NEAR_CM
+    int "Distance threshold for 'near' (cm)"
+    depends on APP_ENABLE_ULTRASONIC
+    default 50
+
+config APP_PRESENT_BRIGHTNESS
+    int "Brightness when presence detected (%)"
+    range 0 100
+    default 20
+
+config APP_NEAR_BRIGHTNESS
+    int "Brightness when someone is near (%)"
+    range 0 100
+    default 100
+
+config APP_NEAR_EXTRA_LEDS
+    int "Extra LEDs to light when near"
+    default 2
+
+endmenu

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -40,3 +40,75 @@ bool app_config_ota_skip_cert_validation(void) {
 #endif
 }
 
+bool app_config_pir_enabled(void) {
+#ifdef CONFIG_APP_ENABLE_PIR
+    return true;
+#else
+    return false;
+#endif
+}
+
+int app_config_pir_gpio(void) {
+#ifdef CONFIG_APP_ENABLE_PIR
+    return CONFIG_APP_PIR_GPIO;
+#else
+    return -1;
+#endif
+}
+
+bool app_config_ultrasonic_enabled(void) {
+#ifdef CONFIG_APP_ENABLE_ULTRASONIC
+    return true;
+#else
+    return false;
+#endif
+}
+
+int app_config_us_trig_gpio(void) {
+#ifdef CONFIG_APP_ENABLE_ULTRASONIC
+    return CONFIG_APP_US_TRIG_GPIO;
+#else
+    return -1;
+#endif
+}
+
+int app_config_us_echo_gpio(void) {
+#ifdef CONFIG_APP_ENABLE_ULTRASONIC
+    return CONFIG_APP_US_ECHO_GPIO;
+#else
+    return -1;
+#endif
+}
+
+int app_config_us_near_cm(void) {
+#ifdef CONFIG_APP_ENABLE_ULTRASONIC
+    return CONFIG_APP_US_NEAR_CM;
+#else
+    return 0;
+#endif
+}
+
+int app_config_present_brightness_pct(void) {
+#ifdef CONFIG_APP_PRESENT_BRIGHTNESS
+    return CONFIG_APP_PRESENT_BRIGHTNESS;
+#else
+    return 0;
+#endif
+}
+
+int app_config_near_brightness_pct(void) {
+#ifdef CONFIG_APP_NEAR_BRIGHTNESS
+    return CONFIG_APP_NEAR_BRIGHTNESS;
+#else
+    return 0;
+#endif
+}
+
+int app_config_near_extra_leds(void) {
+#ifdef CONFIG_APP_NEAR_EXTRA_LEDS
+    return CONFIG_APP_NEAR_EXTRA_LEDS;
+#else
+    return 0;
+#endif
+}
+

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -16,3 +16,13 @@ int app_config_get_led_count(void);
 float app_config_get_default_brightness(void); // returns 0.0..1.0
 bool app_config_ota_skip_cert_validation(void);
 
+bool app_config_pir_enabled(void);
+int app_config_pir_gpio(void);
+bool app_config_ultrasonic_enabled(void);
+int app_config_us_trig_gpio(void);
+int app_config_us_echo_gpio(void);
+int app_config_us_near_cm(void);
+int app_config_present_brightness_pct(void);
+int app_config_near_brightness_pct(void);
+int app_config_near_extra_leds(void);
+

--- a/main/main.c
+++ b/main/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_log.h"
@@ -13,6 +14,7 @@
 #include "time_sync.h"
 #include "effects.h"
 #include "ws2812.h"
+#include "presence.h"
 
 static const char *TAG = "APP";
 
@@ -64,6 +66,43 @@ static void mqtt_ota_schedule(int hour, int minute, const char* url) {
     ota_schedule_set(hour, minute, url);
 }
 
+static void presence_state_changed(presence_state_t state) {
+    int total = app_config_get_led_count();
+    int extra = app_config_near_extra_leds();
+    if (extra > total) extra = 0;
+    int base = total - extra;
+
+    int pct = 0;
+    switch (state) {
+        case PRESENCE_NEAR:
+            pct = app_config_near_brightness_pct();
+            break;
+        case PRESENCE_PRESENT:
+            pct = app_config_present_brightness_pct();
+            break;
+        default:
+            pct = 0;
+            break;
+    }
+
+    rgb_t high = {255,255,255};
+    high.r = high.g = high.b = (uint8_t)(pct * 255 / 100);
+    rgb_t off = {0,0,0};
+
+    rgb_t *buf = calloc(total, sizeof(rgb_t));
+    if (!buf) return;
+
+    for (int i = 0; i < base; ++i) buf[i] = high;
+    if (state == PRESENCE_NEAR) {
+        for (int i = base; i < total; ++i) buf[i] = high;
+    } else {
+        for (int i = base; i < total; ++i) buf[i] = off;
+    }
+
+    ws2812_set_colors(total, buf);
+    free(buf);
+}
+
 void app_main(void) {
     nvs_init_robust();
 
@@ -94,6 +133,10 @@ void app_main(void) {
     };
     ESP_ERROR_CHECK(mqtt_ctrl_start(&cbs));
     mqtt_ctrl_publish_info();
+
+#if CONFIG_APP_ENABLE_PIR || CONFIG_APP_ENABLE_ULTRASONIC
+    ESP_ERROR_CHECK(presence_start(presence_state_changed));
+#endif
 
     ESP_LOGI(TAG, "Setup complete");
     while (true) {

--- a/main/presence.c
+++ b/main/presence.c
@@ -1,0 +1,105 @@
+#include "presence.h"
+#include "app_config.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+#include "esp_timer.h"
+#include "esp_log.h"
+#include "esp_rom_sys.h"
+
+static const char *TAG = "presence";
+static presence_cb_t s_cb = NULL;
+static presence_state_t s_state = PRESENCE_NONE;
+
+#if CONFIG_APP_ENABLE_ULTRASONIC
+static int measure_distance_cm(void)
+{
+    gpio_set_level(CONFIG_APP_US_TRIG_GPIO, 0);
+    esp_rom_delay_us(2);
+    gpio_set_level(CONFIG_APP_US_TRIG_GPIO, 1);
+    esp_rom_delay_us(10);
+    gpio_set_level(CONFIG_APP_US_TRIG_GPIO, 0);
+
+    int64_t start = esp_timer_get_time();
+    while (gpio_get_level(CONFIG_APP_US_ECHO_GPIO) == 0) {
+        if (esp_timer_get_time() - start > 30000) return -1; // timeout 30ms
+    }
+    int64_t echo_start = esp_timer_get_time();
+    while (gpio_get_level(CONFIG_APP_US_ECHO_GPIO) == 1) {
+        if (esp_timer_get_time() - echo_start > 30000) return -1;
+    }
+    int64_t echo_end = esp_timer_get_time();
+    int64_t pulse_width = echo_end - echo_start; // microseconds
+    int distance = (int)(pulse_width * 0.034f / 2.0f); // in cm
+    return distance;
+}
+#endif
+
+static presence_state_t determine_state(void)
+{
+#if CONFIG_APP_ENABLE_ULTRASONIC
+    int dist = measure_distance_cm();
+    if (dist > 0 && dist <= CONFIG_APP_US_NEAR_CM) {
+        return PRESENCE_NEAR;
+    }
+#endif
+#if CONFIG_APP_ENABLE_PIR
+    if (gpio_get_level(CONFIG_APP_PIR_GPIO)) {
+        return PRESENCE_PRESENT;
+    }
+#endif
+    return PRESENCE_NONE;
+}
+
+static void presence_task(void *arg)
+{
+    (void)arg;
+    for (;;) {
+        presence_state_t new_state = determine_state();
+        if (new_state != s_state) {
+            s_state = new_state;
+            if (s_cb) s_cb(s_state);
+        }
+        vTaskDelay(pdMS_TO_TICKS(200));
+    }
+}
+
+esp_err_t presence_start(presence_cb_t cb)
+{
+#if !(CONFIG_APP_ENABLE_PIR || CONFIG_APP_ENABLE_ULTRASONIC)
+    return ESP_ERR_NOT_SUPPORTED;
+#else
+    s_cb = cb;
+#if CONFIG_APP_ENABLE_PIR
+    gpio_config_t pir_conf = {
+        .pin_bit_mask = 1ULL << CONFIG_APP_PIR_GPIO,
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&pir_conf);
+#endif
+#if CONFIG_APP_ENABLE_ULTRASONIC
+    gpio_config_t trig = {
+        .pin_bit_mask = 1ULL << CONFIG_APP_US_TRIG_GPIO,
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&trig);
+    gpio_config_t echo = {
+        .pin_bit_mask = 1ULL << CONFIG_APP_US_ECHO_GPIO,
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&echo);
+#endif
+    xTaskCreate(presence_task, "presence", 4096, NULL, 5, NULL);
+    ESP_LOGI(TAG, "Presence monitoring started");
+    return ESP_OK;
+#endif
+}

--- a/main/presence.h
+++ b/main/presence.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <esp_err.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PRESENCE_NONE = 0,
+    PRESENCE_PRESENT,
+    PRESENCE_NEAR
+} presence_state_t;
+
+typedef void (*presence_cb_t)(presence_state_t state);
+
+esp_err_t presence_start(presence_cb_t cb);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- add optional presence module supporting PIR and HC-SR04 sensors
- expose sensor and brightness options via menuconfig
- integrate presence states into LED control

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esptool`
- `pip install idf-component-manager`


------
https://chatgpt.com/codex/tasks/task_e_68ad64168cd483268cb22f8641a1c3a8